### PR TITLE
いろいろリファクタリング

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
         <link rel="stylesheet" href="css/libs/oj/v2.0.1/alta/oj-alta-min.css"/>
         <link href='http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.min.css' rel='stylesheet' type='text/css'/>
         <script src='http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.bundled.min.js'></script>
+        <script src="js/require-config.js"></script>
         <script data-main="js/main" src="js/libs/require/require.js"></script>
     </head>
     <body>
@@ -35,7 +36,7 @@
                                 <br/>
                                 <div  id="sparql_textarea"></div>
                                 <br/>
-                                <button data-bind="click: Search">Run Query</button>
+                                <button data-bind="click: search">Run Query</button>
                                 <br/><br/>
                             </div>
                         </div>
@@ -54,8 +55,8 @@
                         </table>
                         <script id="empRowTemplate" type="text/html">
                             <tr>
-                                <td data-bind="text: film_name"></td>
-                                <td data-bind="text: screen_time"></td>
+                                <td data-bind="text: name"></td>
+                                <td data-bind="text: birthYear"></td>
                             </tr>
                             </script>
                             <!-- テーブルの設定: ここまで -->

--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
         <link rel="icon" type="image/x-icon" href="css/images/favicon.ico"/>
         <link rel="stylesheet" href="css/libs/oj/v2.0.1/alta/oj-alta-min.css"/>
         <link href='http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.min.css' rel='stylesheet' type='text/css'/>
-        <script src='http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.bundled.min.js'></script>
         <script src="js/require-config.js"></script>
         <script data-main="js/main" src="js/libs/require/require.js"></script>
     </head>

--- a/index_Bar.html
+++ b/index_Bar.html
@@ -11,6 +11,7 @@
         <link rel="stylesheet" href="css/libs/oj/v2.0.1/alta/oj-alta-min.css"/>
         <link href='http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.min.css' rel='stylesheet' type='text/css'/>
         <script src='http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.bundled.min.js'></script>
+        <script src="js/require-config.js"></script>
         <script data-main="js/main_Bar" src="js/libs/require/require.js"></script>
     </head>
     <body>
@@ -29,13 +30,13 @@
                 <div class="oj-flex">
                     <!-- テキストエリア及びボタンの設定:  ここから -->
                     <div class="oj-panel oj-margin oj-flex-item">
-                        <div class="oj-flex">  
+                        <div class="oj-flex">
                             <div class="oj-flex-item">
                                 <label for="sparql_textarea" class="oj-label">Query Text</label>
                                 <br/>
 				<div id="sparql_textarea"></div>
                                 <br/>
-                                <button data-bind="click: Search">Run Query</button>
+                                <button data-bind="click: search">Run Query</button>
                                 <br/><br/>
                             </div>
                         </div>

--- a/index_Bar.html
+++ b/index_Bar.html
@@ -10,7 +10,6 @@
         <link rel="icon" type="image/x-icon" href="css/images/favicon.ico"/>
         <link rel="stylesheet" href="css/libs/oj/v2.0.1/alta/oj-alta-min.css"/>
         <link href='http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.min.css' rel='stylesheet' type='text/css'/>
-        <script src='http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.bundled.min.js'></script>
         <script src="js/require-config.js"></script>
         <script data-main="js/main_Bar" src="js/libs/require/require.js"></script>
     </head>

--- a/index_Pie.html
+++ b/index_Pie.html
@@ -10,7 +10,6 @@
         <link rel="icon" type="image/x-icon" href="css/images/favicon.ico"/>
         <link rel="stylesheet" href="css/libs/oj/v2.0.1/alta/oj-alta-min.css"/>
         <link href='http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.min.css' rel='stylesheet' type='text/css'/>
-        <script src='http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.bundled.min.js'></script>
         <script src="js/require-config.js"></script>
         <script data-main="js/main_Pie" src="js/libs/require/require.js"></script>
     </head>

--- a/index_Pie.html
+++ b/index_Pie.html
@@ -9,6 +9,9 @@
         <title>JET SPARQL</title>
         <link rel="icon" type="image/x-icon" href="css/images/favicon.ico"/>
         <link rel="stylesheet" href="css/libs/oj/v2.0.1/alta/oj-alta-min.css"/>
+        <link href='http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.min.css' rel='stylesheet' type='text/css'/>
+        <script src='http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.bundled.min.js'></script>
+        <script src="js/require-config.js"></script>
         <script data-main="js/main_Pie" src="js/libs/require/require.js"></script>
     </head>
     <body>
@@ -27,16 +30,12 @@
                 <div class="oj-flex">
                     <!-- テキストエリア及びボタンの設定:  ここから -->
                     <div class="oj-panel oj-margin oj-flex-item">
-                        <div class="oj-flex">  
+                        <div class="oj-flex">
                             <div class="oj-flex-item">
                                 <label for="sparql_textarea" class="oj-label">Query Text</label>
                                 <br/>
-                                <textarea  id="sparql_textarea" 
-                                           style="resize: both;  width: 700px; height: 200px;"
-                                           data-bind="ojComponent: {component: 'ojTextArea', 
-                                        value: Keyword}" ></textarea>
-                                <br/>
-                                <button data-bind="click: Search">Run Query</button>
+                                <div id="sparql_textarea"></div>                                <br/>
+                                <button data-bind="click: search">Run Query</button>
                                 <br/><br/>
                             </div>
                         </div>
@@ -72,9 +71,9 @@
         }"
                                  style="max-width:500px;width:500px;height:500px;">
                             </div>
-                        </div> 
+                        </div>
                         <!-- 円グラフの設定:  ここまで -->
-                        
+
                     </div>
             </main>
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -1,33 +1,12 @@
 "use strict";
 
-requirejs.config({
-    // ロードする（可能性のある）JavaScriptライブラリの構成情報
-    paths: {
-        "knockout": "libs/knockout/knockout-3.4.0.debug",
-        "jquery": "libs/jquery/jquery-2.1.3",
-        "jqueryui-amd": "libs/jquery/jqueryui-amd-1.11.4",
-        "promise": "libs/es6-promise/promise-1.0.0",
-        "hammerjs": "libs/hammer/hammer-2.0.4",
-        "ojdnd": "libs/dnd-polyfill/dnd-polyfill-1.0.0",
-        "ojs": "libs/oj/v2.0.1/debug",
-        "ojL10n": "libs/oj/v2.0.1/ojL10n",
-        "ojtranslations": "libs/oj/v2.0.1/resources",
-        "text": "libs/require/text",
-        "signals": "libs/js-signals/signals"
-    },
-    // AMD (Asynchronous Module Definition; ライブラリのモジュール化や非同期ロードのためのお約束) に
-    // 非対応のライブラリをモジュール化するための構成
-    shim: {
-        "jquery": {
-            exports: ["jQuery", "$"]
-        }
-    }
-});
 require([
     // このモジュールが依存しているモジュールたち
     "ojs/ojcore",
     "knockout",
     "jquery",
+    "factory",
+    "main_view_model",
     "ojs/ojknockout",
     "ojs/ojmodel",
     "ojs/ojknockout-model",
@@ -37,38 +16,15 @@ require([
     "ojs/ojpagingcontrol",
     "ojs/ojchart",
     "ojs/ojbutton",
-    "ojs/ojinputtext"
-], function (oj, ko, $) {
-
-    // リソースのレコードを表すオブジェクトの定義
-    var DataModel = oj.Model.extend({
-        idAttribute: "dataId",
-        parse: function (item) {
-            // JSON オブジェクトから ViewModel オブジェクトで使用する形式に変換する
-            return {
-                film_name: item.name["value"]
-                , screen_time: item.birthYear["value"]
-            };
+    "ojs/ojinputtext",
+], function (oj, ko, $, factory, MainViewModel) {
+    var parseFunction = function(item){
+        return {
+            name: item.name["value"],
+            birthYear: item.birthYear["value"]
         }
-    });
-
-    var url = "http://ja.dbpedia.org/sparql";
-    var graphuri = "http://ja.dbpedia.org";
-    var query;
-    // リソースのコレクション表すオブジェクトの定義
-    var DataCollection = oj.Collection.extend({
-        url: url + "?default-graph-uri=" + encodeURIComponent(graphuri) + "&query=" + encodeURIComponent(query) + "&format=application%2Fsparql-results%2Bjson&timeout=0&debug=on",
-        model: new DataModel(),
-        parse: function (response) {
-            return response.results.bindings;
-        }
-    });
-    // index.html 内の id="mainContent" の状態を保持する ViewModel
-    function MainViewModel() {
-        var self = this;
-
-        //テキストエリアの要素の定義
-        var defaultQueryKeyword = 'SELECT DISTINCT ?name ?birthYear\n\
+    }
+    var defaultQueryKeyword = 'SELECT DISTINCT ?name ?birthYear\n\
 WHERE {\n\
   ?s <http://ja.dbpedia.org/property/生日> 1 ;\n\
     <http://ja.dbpedia.org/property/生月> 1 ;\n\
@@ -76,57 +32,10 @@ WHERE {\n\
     rdfs:label ?name .\n\
 }\n\
 ORDER BY ?birthYear'
-        self.query = defaultQueryKeyword;
+    var dataCollection = factory.createCollection(parseFunction);
+    var mainViewModel = new MainViewModel(dataCollection, defaultQueryKeyword, 'sparql_textarea');
 
-        //ボタン実行時に呼び出されるファンクションの定義
-        self.Search = function (test, event) {
-            self.query = self.yasqe.getValueWithoutComments();
-            self.DataCollectionFetch(self.query);
-        };
-
-        // Knockout.jsによって監視されているので双方向データバインドが有効なプロパティ
-        self.titleLabel = ko.observable("JET SPARQL");
-        self.data = ko.observableArray();
-
-        // RESTサービス呼び出しのための Collectionのインスタンスを生成
-        self.DataCollection = new DataCollection();
-        //テキストエリアに入力したSPARQL文を引数にRESTサービスを呼び出し
-        self.DataCollectionFetch = function (queryParam) {
-            var url = "http://ja.dbpedia.org/sparql";
-            var graphuri = "http://ja.dbpedia.org";
-            self.DataCollection.url = url + "?default-graph-uri=" + encodeURIComponent(graphuri) + "&query=" + encodeURIComponent(queryParam) + "&format=application%2Fsparql-results%2Bjson&timeout=0&debug=on";
-
-            self.DataCollection.fetch({
-                success: function (collection, response, options) {
-                    // サービス呼び出しが成功した時の実行されるコールバック関数
-                    self.data(oj.KnockoutUtils.map(collection));
-                },
-                error: function (jqXHR, textStatus, errorThrown) {
-                    //   oj.Logger.error("Error: " + textStatus);
-                    alert("Error: " + textStatus);
-                }
-            });
-        };
-        self.DataCollectionFetch(self.query);
-        // 表形式（ojTable コンポーネント）で表示されるデータのコレクション
-        // self.data に変更があるとコールバック関数が呼ばれる
-        self.tableDataSource = ko.computed(function () {
-            return new oj.PagingTableDataSource(new oj.ArrayTableDataSource(self.data()));
-        });
-    };
-
-    $(document).ready(function () {
-        //MainViewModelのインスタンス作成
-        var mainViewModel = new MainViewModel();
-        // yasqeのインスタンス作成
-        var yasqe = YASQE(document.getElementById("sparql_textarea"));
-
-        // MainViewModelのインスタンスからyasqeオブジェクトを参照するために、プロパティを設定
-        mainViewModel.yasqe = yasqe
-
-        // エディタにプレースホルダ的にデフォルトのクエリを設定する
-        yasqe.setValue(mainViewModel.query)
-
+    $(document).ready(function(){
         ko.applyBindings(mainViewModel, document.getElementById("mainContent"));
     });
 });

--- a/js/main_Bar.js
+++ b/js/main_Bar.js
@@ -1,155 +1,46 @@
 "use strict";
 
-requirejs.config({
-	// ロードする（可能性のある）JavaScriptライブラリの構成情報
-	paths: {
-		"knockout": "libs/knockout/knockout-3.4.0.debug",
-		"jquery": "libs/jquery/jquery-2.1.3",
-		"jqueryui-amd": "libs/jquery/jqueryui-amd-1.11.4",
-		"promise": "libs/es6-promise/promise-1.0.0",
-		"hammerjs": "libs/hammer/hammer-2.0.4",
-		"ojdnd": "libs/dnd-polyfill/dnd-polyfill-1.0.0",
-		"ojs": "libs/oj/v2.0.1/debug",
-		"ojL10n": "libs/oj/v2.0.1/ojL10n",
-		"ojtranslations": "libs/oj/v2.0.1/resources",
-		"text": "libs/require/text",
-		"signals": "libs/js-signals/signals"
-	},
-	// AMD (Asynchronous Module Definition; ライブラリのモジュール化や非同期ロードのためのお約束) に
-	// 非対応のライブラリをモジュール化するための構成
-	shim: {
-		"jquery": {
-			exports: ["jQuery", "$"]
-		}
-	}
-});
 require([
-	// このモジュールが依存しているモジュールたち
-	"ojs/ojcore",
-	"knockout",
-	"jquery",
-	"ojs/ojknockout",
-	"ojs/ojmodel",
-	"ojs/ojknockout-model",
-	"ojs/ojarraytabledatasource",
-	"ojs/ojpagingtabledatasource",
-	"ojs/ojtable",
-	"ojs/ojpagingcontrol",
-	"ojs/ojchart",
-	"ojs/ojbutton",
-	"ojs/ojinputtext"
+    // このモジュールが依存しているモジュールたち
+    "ojs/ojcore",
+    "knockout",
+    "jquery",
+    "factory",
+    "bar_view_model",
+    "ojs/ojknockout",
+    "ojs/ojmodel",
+    "ojs/ojknockout-model",
+    "ojs/ojarraytabledatasource",
+    "ojs/ojpagingtabledatasource",
+    "ojs/ojtable",
+    "ojs/ojpagingcontrol",
+    "ojs/ojchart",
+    "ojs/ojbutton",
+    "ojs/ojinputtext"
+], function (oj, ko, $, factory, BarViewModel) {
+    var parseFunction = function (item) {
+        // JSON オブジェクトから ViewModel オブジェクトで使用する形式に変換する
+        return {
+            film_name: item.film_name["value"],
+            screen_time: item.screen_time["value"]
+        };
+    };
 
-], function (oj, ko, $) {
-
-	// リソースのレコードを表すオブジェクトの定義
-	var DataModel = oj.Model.extend({
-		idAttribute: "dataId",
-		parse: function (item) {
-			// JSON オブジェクトから ViewModel オブジェクトで使用する形式に変換する
-			return {
-				film_name: item.film_name["value"]
-				, screen_time: item.screen_time["value"]
-			};
-		}
-	});
-
-	var url = "http://ja.dbpedia.org/sparql";
-	var graphuri = "http://ja.dbpedia.org";
-	var query;
-	// リソースのコレクション表すオブジェクトの定義
-	var DataCollection = oj.Collection.extend({
-		url: url + "?default-graph-uri=" + encodeURIComponent(graphuri) + "&query=" + encodeURIComponent(query) + "&format=application%2Fsparql-results%2Bjson&timeout=0&debug=on",
-		model: new DataModel(),
-		parse: function (response) {
-			return response.results.bindings;
-		}
-	});
-	// index.html 内の id="mainContent" の状態を保持する ViewModel
-	function MainViewModel() {
-		var self = this;
-				
-		//テキストエリアの要素の定義
-		var defaultQueryKeyword = 'PREFIX dbpedia-ja: <http://ja.dbpedia.org/resource/>  \n\
+    var defaultQueryKeyword = 'PREFIX dbpedia-ja: <http://ja.dbpedia.org/resource/>  \n\
 PREFIX dbpedia-owl: <http://dbpedia.org/ontology/>  \n\
 PREFIX prop-ja: <http://ja.dbpedia.org/property/>  \n\
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>  \n\
 SELECT ?film_name ?screen_time  \n\
 WHERE { ?film dbpedia-owl:director  \n\
-		  dbpedia-ja:ビートたけし ;  \n\
-		  prop-ja:上映時間 ?screen_time  ;  \n\
-		  rdfs:label ?film_name . }  \n\
-ORDER BY DESC(?screen_time)'
+    dbpedia-ja:ビートたけし ;  \n\
+    prop-ja:上映時間 ?screen_time  ;  \n\
+    rdfs:label ?film_name . }  \n\
+ORDER BY DESC(?screen_time)';
 
-		self.query = defaultQueryKeyword;
-				
-		//ボタン実行時に呼び出されるファンクションの定義
-		self.Search = function (test, event) {
-			self.query = self.yasqe.getValueWithoutComments();
-			self.DataCollectionFetch(test.query);
-		};
+    var dataCollection = factory.createCollection(parseFunction);
+    var barViewModel = new BarViewModel(dataCollection, defaultQueryKeyword, 'sparql_textarea');
 
-		// Knockout.jsによって監視されているので双方向データバインドが有効なプロパティ
-		self.titleLabel = ko.observable("JET SPARQL");
-		self.data = ko.observableArray();
-
-		// RESTサービス呼び出しのための Collectionのインスタンスを生成
-		self.DataCollection = new DataCollection();
-		//テキストエリアに入力したSPARQL文を引数にRESTサービスを呼び出し
-		self.DataCollectionFetch = function (queryParam) {
-			var url = "http://ja.dbpedia.org/sparql";
-			var graphuri = "http://ja.dbpedia.org";
-			self.DataCollection.url = url + "?default-graph-uri=" + encodeURIComponent(graphuri) + "&query=" + encodeURIComponent(queryParam) + "&format=application%2Fsparql-results%2Bjson&timeout=0&debug=on";
-			self.DataCollection.fetch({
-				success: function (collection, response, options) {
-					// サービス呼び出しが成功した時の実行されるコールバック関数
-					self.data(oj.KnockoutUtils.map(collection));
-				},
-				error: function (jqXHR, textStatus, errorThrown) {
-					//   oj.Logger.error("Error: " + textStatus);
-					alert("Error: " + textStatus);
-				}
-			});
-		};
-		self.DataCollectionFetch(self.query);
-
-		// グラフ（ojChart コンポーネント）で表示するためのデータを抽出
-		// self.data に変更があるとコールバック関数が呼ばれる
-		// チャートのデータは次のようなオブジェクトの配列
-		// { name: <系列データの名前>, items: [ <グループ#1 の値>, <グループ#2の値>, ... ] }
-		self.chartSeries = ko.computed(function () {
-			var seriesValues = [];
-			if (self.data().length !== 0) {
-				var values = {};
-				$.each(self.data(), function (index,data) {
-					var film_name = data.film_name();
-					var screen_time = data.screen_time();
-					values[film_name] = {name: film_name, items: [screen_time]};
-							
-				});
-				$.each(values, function (key, value) {
-					seriesValues.push(value);
-			});
-			}
-			return seriesValues;
-		});
-
-	};
-
-	$(document).ready(function () {
-
-		// MainViewModelのインスタンス作成
-		var mainViewModel = new MainViewModel();
-
-		// yasqeのインスタンス作成
-		var yasqe = YASQE(document.getElementById("sparql_textarea"));
-
-		// MainViewModelのインスタンスからyasqeオブジェクトを参照するために、プロパティを設定
-		mainViewModel.yasqe = yasqe
-
-		// エディタにプレースホルダ的にデフォルトのクエリを設定する
-		yasqe.setValue(mainViewModel.query)
-
-		ko.applyBindings(mainViewModel, document.getElementById("mainContent"));
-	});
-
+    $(document).ready(function () {
+        ko.applyBindings(barViewModel, document.getElementById("mainContent"));
+    });
 });

--- a/js/main_Pie.js
+++ b/js/main_Pie.js
@@ -1,150 +1,45 @@
-
 "use strict";
 
-requirejs.config({
-  // ロードする（可能性のある）JavaScriptライブラリの構成情報
-  paths: {
-    "knockout":       "libs/knockout/knockout-3.4.0.debug",
-    "jquery":         "libs/jquery/jquery-2.1.3",
-    "jqueryui-amd":   "libs/jquery/jqueryui-amd-1.11.4",
-    "promise":        "libs/es6-promise/promise-1.0.0",
-    "hammerjs":       "libs/hammer/hammer-2.0.4",
-    "ojdnd":          "libs/dnd-polyfill/dnd-polyfill-1.0.0",
-    "ojs":            "libs/oj/v2.0.1/debug",
-    "ojL10n":         "libs/oj/v2.0.1/ojL10n",
-    "ojtranslations": "libs/oj/v2.0.1/resources",
-    "text":           "libs/require/text",
-    "signals":        "libs/js-signals/signals"
-  },
-  // AMD (Asynchronous Module Definition; ライブラリのモジュール化や非同期ロードのためのお約束) に
-  // 非対応のライブラリをモジュール化するための構成
-  shim: {
-    "jquery": {
-      exports: ["jQuery", "$"]
-    }
-  }
-});
 require([
-  // このモジュールが依存しているモジュールたち
-  "ojs/ojcore",
-  "knockout",
-  "jquery",
-  "ojs/ojknockout",
-  "ojs/ojmodel",
-  "ojs/ojknockout-model",
-  "ojs/ojarraytabledatasource",
-  "ojs/ojpagingtabledatasource",
-  "ojs/ojtable",
-  "ojs/ojpagingcontrol",
-  "ojs/ojchart",
-  "ojs/ojbutton",
-  "ojs/ojinputtext",
-  "ojs/ojselectcombobox",
-  "ojs/ojinputnumber",
-  "ojs/ojselectcombobox"
-  
-],
-function(oj, ko, $) {
-
-  // リソースのレコードを表すオブジェクトの定義
-  var DataModel = oj.Model.extend({
-    idAttribute: "dataId",
-    parse: function (item) {
-      // JSON オブジェクトから ViewModel オブジェクトで使用する形式に変換する
-      return {
-        month: item.month["value"]
-      , count: item.count["value"]
-      };
-    }
-  });
-
-  var url = "http://ja.dbpedia.org/sparql";
-  var graphuri = "http://ja.dbpedia.org";
-  var query = "PREFIX dbpedia-ja: <http://ja.dbpedia.org/resource/> PREFIX dbpedia-owl: <http://dbpedia.org/ontology/> PREFIX prop-ja: <http://ja.dbpedia.org/property/> PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> SELECT ?film_name ?screen_time WHERE { ?film dbpedia-owl:director dbpedia-ja:ビートたけし ; prop-ja:上映時間 ?screen_time  ; rdfs:label ?film_name . } ORDER BY DESC(?screen_time)";
-  // リソースのコレクション表すオブジェクトの定義
-  var DataCollection = oj.Collection.extend({
-    url:   url + "?default-graph-uri=" + encodeURIComponent(graphuri) + "&query=" + encodeURIComponent(query) + "&format=application%2Fsparql-results%2Bjson&timeout=0&debug=on",
-    model: new DataModel(),
-    parse: function (response){
-    return response.results.bindings;
-    }
- });
-  // index.html 内の id="mainContent" の状態を保持する ViewModel
-  function MainViewModel() {
-    var self = this;
-    
-    //円グラフの要素の定義 
-        self.innerRadius = ko.observable(0.6);
-        self.centerLabel = ko.observable('# Born on the 1st of each month');
-        self.labelStyle = ko.observable('font-size:20px;color:#999999;');
-        var pieGroups = ["Group A"];
-        self.pieGroupsValue = ko.observableArray(pieGroups);
-  
-                //テキストエリアの要素の定義
-     self.Keyword  = ko.observable('SELECT  (count(?label) AS ?count) ?month \n\
+    // このモジュールが依存しているモジュールたち
+    "ojs/ojcore",
+    "knockout",
+    "jquery",
+    "factory",
+    "pie_view_model",
+    "main_view_model",
+    "ojs/ojknockout",
+    "ojs/ojmodel",
+    "ojs/ojknockout-model",
+    "ojs/ojarraytabledatasource",
+    "ojs/ojpagingtabledatasource",
+    "ojs/ojtable",
+    "ojs/ojpagingcontrol",
+    "ojs/ojchart",
+    "ojs/ojbutton",
+    "ojs/ojinputtext",
+    "ojs/ojselectcombobox",
+    "ojs/ojinputnumber",
+    "ojs/ojselectcombobox"
+], function(oj, ko, $, factory, PieViewModel) {
+    var parseFunction = function(item){
+        return {
+            month: item.month["value"],
+            count: item.count["value"]
+        };
+    };
+    var defaultQueryKeyword = 'SELECT  (count(?label) AS ?count) ?month \n\
 WHERE {\n\
-  ?s <http://ja.dbpedia.org/property/生日> 1 ;\n\
-     <http://ja.dbpedia.org/property/生月> ?month ;\n\
-     rdfs:label ?label .\n\
+?s <http://ja.dbpedia.org/property/生日> 1 ;\n\
+<http://ja.dbpedia.org/property/生月> ?month ;\n\
+rdfs:label ?label .\n\
 }\n\
 GROUP BY ?month\n\
-ORDER BY ?month');
-      
-     self.query = self.Keyword();
-     self.Search = function(test, event) {
-         self.query = self.Keyword();
-         self.EmpCollectionFetch(self.query);
-     };
+ORDER BY ?month';
+    var dataCollection = factory.createCollection(parseFunction);
+    var pieViewModel = new PieViewModel(dataCollection, defaultQueryKeyword, 'sparql_textarea');
 
-    // Knockout.jsによって監視されているので双方向データバインドが有効なプロパティ
-    self.titleLabel  = ko.observable("JET SPARQL");
-    self.data   = ko.observableArray();
-    
-    // RESTサービス呼び出しのための Collectionのインスタンスを生成
-    self.DataCollection = new DataCollection();
-    //入力したSPARQLをurlに挿入
-    self.DataCollectionFetch = function(queryParam){
-            var url = "http://ja.dbpedia.org/sparql";
-            var graphuri = "http://ja.dbpedia.org";
-            self.DataCollection.url =  url + "?default-graph-uri=" + encodeURIComponent(graphuri) + "&query=" + encodeURIComponent(queryParam) + "&format=application%2Fsparql-results%2Bjson&timeout=0&debug=on";
-           
-          self.DataCollection.fetch({
-          success: function (collection, response, options) {
-            // サービス呼び出しが成功した時の実行されるコールバック関数
-            self.data(oj.KnockoutUtils.map(collection));
-          },
-          error: function (jqXHR, textStatus, errorThrown) {
-          //   oj.Logger.error("Error: " + textStatus);
-          alert("Error: " + textStatus);
-          }
-        });
-    };
-    self.DataCollectionFetch(self.query);
-
-    // グラフ（ojChart コンポーネント）で表示するためのデータを抽出
-    // self.data に変更があるとコールバック関数が呼ばれる
-    // チャートのデータは次のようなオブジェクトの配列
-    // { name: <系列データの名前>, items: [ <グループ#1 の値>, <グループ#2の値>, ... ] }
-    self.chartSeries = ko.computed(function () {
-      var seriesValues = [];
-      if (self.data().length !== 0) {
-        var values = {};
-        $.each(self.data(), function (index, data) {
-          var month    = data.month()+ "月";
-          var count   = data.count();
-            values[month] = { name: month, items: [ count ] };
-        });
-        $.each(values, function (key, value) {
-          seriesValues.push(value);
-        });
-      }
-      return seriesValues;
+    $(document).ready(function() {
+        ko.applyBindings(pieViewModel, document.getElementById("mainContent"));
     });
-    
-  };
-
-  $(document).ready(function() {
-    ko.applyBindings(new MainViewModel(), document.getElementById("mainContent"));
-  });
-
 });

--- a/js/require-config.js
+++ b/js/require-config.js
@@ -15,13 +15,17 @@ var require = {
       "factory": "utils/factory",
       "main_view_model": "view_models/main",
       "pie_view_model": "view_models/pie",
-      "bar_view_model": "view_models/bar"
+      "bar_view_model": "view_models/bar",
+      "yasqe": "http://cdn.jsdelivr.net/yasqe/2.10.0/yasqe.bundled.min"
   },
   // AMD (Asynchronous Module Definition; ライブラリのモジュール化や非同期ロードのためのお約束) に
   // 非対応のライブラリをモジュール化するための構成
   shim: {
       "jquery": {
           exports: ["jQuery", "$"]
+      },
+      "yasqe": {
+          exports: "YASQE"
       }
   }
 };

--- a/js/require-config.js
+++ b/js/require-config.js
@@ -1,0 +1,27 @@
+var require = {
+  // ロードする（可能性のある）JavaScriptライブラリの構成情報
+  paths: {
+      "knockout": "libs/knockout/knockout-3.4.0.debug",
+      "jquery": "libs/jquery/jquery-2.1.3",
+      "jqueryui-amd": "libs/jquery/jqueryui-amd-1.11.4",
+      "promise": "libs/es6-promise/promise-1.0.0",
+      "hammerjs": "libs/hammer/hammer-2.0.4",
+      "ojdnd": "libs/dnd-polyfill/dnd-polyfill-1.0.0",
+      "ojs": "libs/oj/v2.0.1/debug",
+      "ojL10n": "libs/oj/v2.0.1/ojL10n",
+      "ojtranslations": "libs/oj/v2.0.1/resources",
+      "text": "libs/require/text",
+      "signals": "libs/js-signals/signals",
+      "factory": "utils/factory",
+      "main_view_model": "view_models/main",
+      "pie_view_model": "view_models/pie",
+      "bar_view_model": "view_models/bar"
+  },
+  // AMD (Asynchronous Module Definition; ライブラリのモジュール化や非同期ロードのためのお約束) に
+  // 非対応のライブラリをモジュール化するための構成
+  shim: {
+      "jquery": {
+          exports: ["jQuery", "$"]
+      }
+  }
+};

--- a/js/utils/factory.js
+++ b/js/utils/factory.js
@@ -1,0 +1,45 @@
+define([
+  "ojs/ojcore",
+  "ojs/ojknockout",
+  "ojs/ojmodel",
+  "ojs/ojknockout-model"
+], function(oj){
+    var factory = {}
+    var sparqlUrl = "http://ja.dbpedia.org/sparql";
+    var graphUri = "http://ja.dbpedia.org";
+
+    factory.createModel = function(parseFunction){
+      var DataModel = oj.Model.extend({
+          idAttribute: "dataId",
+          parse: parseFunction
+      });
+      return new DataModel();
+    };
+
+    function _defineUrl(query){
+        return (sparqlUrl +
+                "?default-graph-uri=" + encodeURIComponent(graphUri) +
+                "&query=" +
+                encodeURIComponent(query) +
+                "&format=application%2Fsparql-results%2Bjson&timeout=0&debug=on");
+    }
+
+    factory.createCollection = function(parseFunction, query){
+        var model = factory.createModel(parseFunction);
+
+        var DataCollection = oj.Collection.extend({
+            query: query,
+            url: _defineUrl(query),
+            model: model,
+            parse: function (response) {
+                return response.results.bindings;
+            }
+        });
+        DataCollection.prototype.updateUrl = function(query){
+            this.query = query;
+            this.url = _defineUrl(query);
+        }
+        return new DataCollection();
+    };
+    return factory;
+});

--- a/js/view_models/bar.js
+++ b/js/view_models/bar.js
@@ -1,0 +1,28 @@
+define(["knockout", "main_view_model"], function(ko, MainViewModel){
+    var BarViewModel = function BarViewModel(dataCollection, defaultQuery, yasqeId) {
+        var self = this;
+        MainViewModel.call(self, dataCollection, defaultQuery, yasqeId);
+
+        // グラフ（ojChart コンポーネント）で表示するためのデータを抽出
+    		// self.data に変更があるとコールバック関数が呼ばれる
+    		// チャートのデータは次のようなオブジェクトの配列
+    		// { name: <系列データの名前>, items: [ <グループ#1 の値>, <グループ#2の値>, ... ] }
+    		self.chartSeries = ko.computed(function () {
+    			  var seriesValues = [];
+    			  if (self.data().length !== 0) {
+    				    var values = {};
+    				    $.each(self.data(), function (index,data) {
+    					      var film_name = data.film_name();
+    					      var screen_time = data.screen_time();
+    					      values[film_name] = {name: film_name, items: [screen_time]};
+    				    });
+        				$.each(values, function (key, value) {
+        					seriesValues.push(value);
+        			  });
+    			  }
+    		    return seriesValues;
+    		});
+    };
+
+    return BarViewModel;
+});

--- a/js/view_models/main.js
+++ b/js/view_models/main.js
@@ -1,0 +1,37 @@
+define(["knockout"], function(ko){
+  var MainViewModel = function MainViewModel(dataCollection, defaultQuery, yasqeId) {
+      var self = this;
+      var yasqe = YASQE(document.getElementById(yasqeId));
+      yasqe.setValue(defaultQuery)
+
+      self.yasqe = yasqe
+      self.titleLabel = ko.observable("JET SPARQL");
+      self.data = ko.observableArray();
+      self.dataCollection = dataCollection;
+
+      self.search = function(test, event) {
+          self.query = self.yasqe.getValueWithoutComments();
+          self.dataCollectionFetch(self.query);
+      };
+
+      self.dataCollectionFetch = function(queryParam) {
+          self.dataCollection.updateUrl(queryParam)
+
+          self.dataCollection.fetch({
+              success: function(collection, response, options) {
+                  self.data(oj.KnockoutUtils.map(collection));
+              },
+              error: function(jqXHR, textStatus, errorThrown) {
+                  alert("Error: " + textStatus);
+              }
+          });
+      };
+
+      self.tableDataSource = ko.computed(function () {
+          return new oj.PagingTableDataSource(new oj.ArrayTableDataSource(self.data()));
+      });
+      self.dataCollectionFetch(defaultQuery);
+    };
+
+    return MainViewModel;
+});

--- a/js/view_models/main.js
+++ b/js/view_models/main.js
@@ -1,4 +1,4 @@
-define(["knockout"], function(ko){
+define(["knockout", "yasqe"], function(ko, YASQE){
   var MainViewModel = function MainViewModel(dataCollection, defaultQuery, yasqeId) {
       var self = this;
       var yasqe = YASQE(document.getElementById(yasqeId));

--- a/js/view_models/pie.js
+++ b/js/view_models/pie.js
@@ -1,0 +1,38 @@
+define(["knockout", "main_view_model"], function(ko, MainViewModel){
+    var PieViewModel = function PieViewModel(dataCollection, defaultQuery, yasqeId) {
+        var self = this;
+        var defaultInnerRadius = 0.6;
+        var defaultCenterLabel = '# Born on the 1st of each month';
+        var defaultLabelStyle = 'font-size:20px;color:#999999;';
+        var pieGroups = ["Group A"];
+
+        MainViewModel.call(self, dataCollection, defaultQuery, yasqeId);
+
+        //円グラフの要素の定義
+        self.innerRadius = ko.observable(defaultInnerRadius);
+        self.centerLabel = ko.observable(defaultCenterLabel);
+        self.labelStyle = ko.observable(defaultLabelStyle);
+        self.pieGroupsValue = ko.observableArray(pieGroups);
+
+        // グラフ（ojChart コンポーネント）で表示するためのデータを抽出
+        // self.data に変更があるとコールバック関数が呼ばれる
+        // チャートのデータは次のようなオブジェクトの配列
+        // { name: <系列データの名前>, items: [ <グループ#1 の値>, <グループ#2の値>, ... ] }
+        self.chartSeries = ko.computed(function() {
+            var seriesValues = [];
+            if (self.data().length !== 0) {
+                var values = {};
+                $.each(self.data(), function(index, data) {
+                    var month    = data.month()+ "月";
+                    var count   = data.count();
+                    values[month] = { name: month, items: [ count ] };
+                });
+                $.each(values, function(key, value) {
+                    seriesValues.push(value);
+                });
+            }
+         return seriesValues;
+       });
+    };
+    return PieViewModel;
+});


### PR DESCRIPTION
## 変更点
- 重複部分（modelとcollectionとViewModel）が重複して記述されていていたので、共通化
　　- MainViewModelクラスを作って、PiewViewModelとBarViewModelはこれを継承する形にした。
　  - modelとcollectionはfactoryモジュールを作って、その中で作成するようにした。
      - jsonをぱーすする際にどのようにぱーすするかを指定するfunctionを引数にする

- requreJSのpathやshimsの設定が毎回重複して記述されていたので共通化
　- js/requirejs-config.jsにまとめてある
　- 各htmlのheadタグ内で以下のようにすればconfigを呼びさせる

```
....
<script src="js/require-config.js"></script>
...
```

- yasqeのみheadタグで呼び出すのはいけてないので, requirejsで管理するようにした。（ただしjsのみ）